### PR TITLE
Submitting batch and odvf code for financial use-case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/__pycache__
 ./__pycache__
+.DS_Store

--- a/Spark/Financial_Market/data_sources/stock_daily_stats.py
+++ b/Spark/Financial_Market/data_sources/stock_daily_stats.py
@@ -1,0 +1,12 @@
+from tecton import HiveConfig, BatchSource, DatetimePartitionColumn
+
+stock_daily_stats = BatchSource(
+    name='stock_daily_stats',
+    batch_config=HiveConfig(
+        database='stock_demo_data',
+        table='stock_daily_stats',
+        timestamp_field='TIMESTAMP'
+    ),
+    owner='nlee@tecton.ai',
+    tags={'release': 'production'}
+)

--- a/Spark/Financial_Market/data_sources/stock_trades.py
+++ b/Spark/Financial_Market/data_sources/stock_trades.py
@@ -1,0 +1,12 @@
+from tecton import HiveConfig, BatchSource, DatetimePartitionColumn
+
+stock_trades = BatchSource(
+    name='stock_trades_batch',
+    batch_config=HiveConfig(
+        database='stock_demo_data',
+        table='stock_trades',
+        timestamp_field='TIMESTAMP'
+    ),
+    owner='nlee@tecton.ai',
+    tags={'release': 'production'}
+)

--- a/Spark/Financial_Market/entities.py
+++ b/Spark/Financial_Market/entities.py
@@ -1,0 +1,9 @@
+from tecton import Entity
+
+stock = Entity(
+    name='stock_ticker',
+    join_keys=['SYMBOL'],
+    description='A stock ticker',
+    owner='nlee@tecton.ai',
+    tags={'release': 'production'}
+)

--- a/Spark/Financial_Market/feature_services/stock_fs.py
+++ b/Spark/Financial_Market/feature_services/stock_fs.py
@@ -1,0 +1,17 @@
+from tecton import FeatureService
+
+from features.batch_features.closing_prices_metrics import closing_price_metrics
+from features.batch_features.todays_closing_price import todays_closing_price
+from features.batch_features.yesterday_closing_price import yesterday_closing_price
+from features.on_demand_features.daily_return_on_demand import percentage_daily_returns
+
+stock_daily_stats_feature_service = FeatureService(
+    name="stock_daily_stats_feature_service",
+    online_serving_enabled=True,
+    features=[
+        todays_closing_price,
+        yesterday_closing_price,
+        percentage_daily_returns,
+        closing_price_metrics,
+    ],
+)

--- a/Spark/Financial_Market/features/batch_features/closing_prices_metrics.py
+++ b/Spark/Financial_Market/features/batch_features/closing_prices_metrics.py
@@ -1,0 +1,39 @@
+from tecton import batch_feature_view, FilteredSource, Aggregation
+from entities import stock
+from data_sources.stock_daily_stats import stock_daily_stats
+from datetime import datetime, timedelta
+
+@batch_feature_view(
+    sources=[FilteredSource(stock_daily_stats)],
+    entities=[stock],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    feature_start_time=datetime(2016, 1, 1),
+    batch_schedule=timedelta(hours = 1),
+    timestamp_field="TIMESTAMP",
+    description="Analysis on closing prices seen over different timespans.",
+    aggregations = [
+        Aggregation(column="CLOSE", function="max", time_window=timedelta(days=3)),
+        Aggregation(column="CLOSE", function="max", time_window=timedelta(days=7)),
+        Aggregation(column="CLOSE", function="max", time_window=timedelta(days=30)),
+        Aggregation(column="CLOSE", function="min", time_window=timedelta(days=3)),
+        Aggregation(column="CLOSE", function="min", time_window=timedelta(days=7)),
+        Aggregation(column="CLOSE", function="min", time_window=timedelta(days=30)),
+        Aggregation(column="CLOSE", function="mean", time_window=timedelta(days=3)),
+        Aggregation(column="CLOSE", function="mean", time_window=timedelta(days=7)),
+        Aggregation(column="CLOSE", function="mean", time_window=timedelta(days=30)),
+    ],
+    aggregation_interval=timedelta(hours=1),
+    name = "closing_prices_metrics"
+)
+def closing_price_metrics(stock_trades_batch):
+    return f"""
+        SELECT
+            SYMBOL,
+            CLOSE,
+            TIMESTAMP
+        FROM
+            {stock_trades_batch}
+        """
+

--- a/Spark/Financial_Market/features/batch_features/daily_transactions_stats.py
+++ b/Spark/Financial_Market/features/batch_features/daily_transactions_stats.py
@@ -1,0 +1,35 @@
+from tecton import batch_feature_view, FilteredSource, Aggregation
+from entities import stock
+from data_sources.stock_trades import stock_trades
+from datetime import datetime, timedelta
+
+@batch_feature_view(
+    sources=[FilteredSource(stock_trades)],
+    entities=[stock],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    feature_start_time=datetime(2016, 1, 1),
+    batch_schedule=timedelta(minutes=60),
+    timestamp_field="TIMESTAMP",
+    description="Analysis on stock trades made each day.",
+    aggregations = [
+        Aggregation(column="PRICE", function="min", time_window=timedelta(minutes=60)),
+        Aggregation(column="PRICE", function="max", time_window=timedelta(minutes=60)),
+        Aggregation(column="TOTAL_SHARES", function="sum", time_window=timedelta(minutes=60)),
+        Aggregation(column="DOLLAR_VOLUME", function="sum", time_window=timedelta(minutes=60))
+    ],
+    aggregation_interval=timedelta(minutes=60),
+    name = "daily_transactions_stats"
+)
+def max_prices_seen(stock_trades_batch):
+    return f"""
+        SELECT
+            SYMBOL,
+            QUANTITY as TOTAL_SHARES,
+            PRICE, 
+            QUANTITY*PRICE as DOLLAR_VOLUME,
+            TIMESTAMP
+        FROM
+            {stock_trades_batch}
+        """

--- a/Spark/Financial_Market/features/batch_features/todays_closing_price.py
+++ b/Spark/Financial_Market/features/batch_features/todays_closing_price.py
@@ -1,0 +1,27 @@
+from tecton import batch_feature_view, FilteredSource
+from entities import stock
+from data_sources.stock_daily_stats import stock_daily_stats
+from datetime import datetime, timedelta
+
+@batch_feature_view(
+    sources=[FilteredSource(stock_daily_stats)],
+    entities=[stock],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    feature_start_time=datetime(2016, 1, 1),
+    batch_schedule=timedelta(hours=1),
+    timestamp_field="TIMESTAMP",
+    description="The closing price of a stock",
+    ttl=timedelta(days=3650)
+)
+def todays_closing_price(stock_trades_batch):
+    return f"""
+        SELECT
+            SYMBOL,
+            CLOSE, 
+            TIMESTAMP
+        FROM
+            {stock_trades_batch}
+        """
+

--- a/Spark/Financial_Market/features/batch_features/yesterday_closing_price.py
+++ b/Spark/Financial_Market/features/batch_features/yesterday_closing_price.py
@@ -1,0 +1,28 @@
+from tecton import batch_feature_view, FilteredSource, Aggregation
+from tecton.aggregation_functions import last
+from entities import stock
+from data_sources.stock_daily_stats import stock_daily_stats
+from datetime import datetime, timedelta
+
+@batch_feature_view(
+    sources=[FilteredSource(stock_daily_stats)],
+    entities=[stock],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    feature_start_time=datetime(2016, 1, 1),
+    batch_schedule=timedelta(hours=1),
+    timestamp_field="TIMESTAMP",
+    description="The previous day's closing price (so you can do a day-to-day comparison)",
+    name = "yesterday_closing_price",
+    ttl=timedelta(days=3650)
+) #crazy enough to work!
+def yesterday_closing_price(stock_trades_batch):
+    return f"""
+        SELECT
+            SYMBOL,
+            LAG(CLOSE) OVER (PARTITION BY SYMBOL ORDER BY TIMESTAMP) as PREVIOUS_CLOSE,
+            TIMESTAMP
+        FROM
+            {stock_trades_batch}
+        """

--- a/Spark/Financial_Market/features/on_demand_features/daily_return_on_demand.py
+++ b/Spark/Financial_Market/features/on_demand_features/daily_return_on_demand.py
@@ -1,0 +1,19 @@
+from tecton import RequestSource, on_demand_feature_view
+from tecton.types import String, Timestamp, Float64, Field
+from features.batch_features.todays_closing_price import todays_closing_price
+from features.batch_features.yesterday_closing_price import yesterday_closing_price
+
+#This ODFV does not require a request input schema; it merely grabs two feature views and makes a real-time calculation.
+output_schema = [Field("percent_daily_return", Float64)]
+
+# Get FV for yesterday's closing price and today's closing price, and then do a calculation
+@on_demand_feature_view(
+    sources=[yesterday_closing_price, todays_closing_price],
+    mode="python",
+    schema=output_schema,
+    description="What is the percent of daily returns after the close today?",
+)
+
+def percentage_daily_returns(yesterday_closing_price, todays_closing_price):
+    percent_return = float(todays_closing_price["CLOSE"] - yesterday_closing_price["PREVIOUS_CLOSE"]) / yesterday_closing_price["PREVIOUS_CLOSE"]
+    return {'percent_daily_return': percent_return}

--- a/Spark/Financial_Market/readme.md
+++ b/Spark/Financial_Market/readme.md
@@ -1,5 +1,10 @@
-# Tecton Fundamentals Tutorial Repo
+# Financial Market Sample Code
 
-This feature repository includes code snippets that show how to build feature pipelines for training and serving, using a fictional financial market use-case, like stock trading. 
+This feature repository includes code snippets that show how to build feature pipelines for training and serving, using a fictional financial market use-case (stock market). 
 
-This repository contains code to generate synthetic batch data in a hive table (Databricks & Spark). 
+### Getting Started
+1. The sample_notebooks folder contains two helper notebooks. One notebook allows you to synthesize fake stock data in a Databricks notebook. You should inspect this notebook, rename the variables to your liking, and register those tables in your hive metastore. Code at the bottom of the notebook will test that the data sources are set up for Tecton access.
+2. Once your synthetic data is ready, create a tecton workspace for this demo.
+3. Run "tecton apply" in the Financial_Market directory to set up all of the data sources, feature views, and on-demand features. 
+4. If all of the above were successful, go back into Databricks and run through the second notebook in sample_notebooks. You'll need to replace the credential variables with your own Tecton credentials. This notebook shows how to access the Tecton features we just created. 
+

--- a/Spark/Financial_Market/readme.md
+++ b/Spark/Financial_Market/readme.md
@@ -1,0 +1,5 @@
+# Tecton Fundamentals Tutorial Repo
+
+This feature repository includes code snippets that show how to build feature pipelines for training and serving, using a fictional financial market use-case, like stock trading. 
+
+This repository contains code to generate synthetic batch data in a hive table (Databricks & Spark). 

--- a/Spark/Financial_Market/sample_notebooks/01_Synthetic_Data_Notebook_StockTrades.py
+++ b/Spark/Financial_Market/sample_notebooks/01_Synthetic_Data_Notebook_StockTrades.py
@@ -1,0 +1,183 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC
+# MAGIC ###Batch Data Creation Notebook
+# MAGIC
+# MAGIC This notebook will create two synthetic stock tables: 
+# MAGIC 1) stock_demo_data.stock_trades: Second-by-second transaction data with price, volume, and timestamp of trade. 
+# MAGIC 2) stock_demo_data.stock_daily_stats: Day-by-day stock data including volume, closing price, low price, and high price. 
+# MAGIC
+# MAGIC ####How to use: 
+# MAGIC
+# MAGIC The notebook attempts to store this data in a schema "stock_demo_data" within Databricks. The Tecton data source is set up with the demo code: Link and Link
+
+# COMMAND ----------
+
+# MAGIC %pip install dbldatagen
+
+# COMMAND ----------
+
+# DBTITLE 1,Generate second-by-second trade data
+from pyspark.sql.types import LongType, IntegerType, StringType
+
+import dbldatagen as dg
+
+stock_tickers = [
+    "ABC", "DEF", "GHI", "JKLM", "NOP"
+]
+
+shuffle_partitions_requested = len(stock_tickers)
+device_population = 100000
+data_rows = 20 * 1000
+partitions_requested = len(stock_tickers)
+
+spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions_requested)
+
+ticker_weights = [
+    2,3,1,1,1
+]
+
+testDataSpec = (
+    dg.DataGenerator(spark, name="device_data_set", rows=data_rows, 
+                     partitions=partitions_requested)
+    .withIdOutput()
+    # we'll use hash of the base field to generate the ids to
+    # avoid a simple incrementing sequence
+    .withColumn("trade_id", "long", minValue=0x1000000000000, omit=True, baseColumnType="hash")
+    .withColumn(
+        "trade_identification", "string", format="0x%013x", baseColumn="trade_id"
+    )
+    .withColumn("SYMBOL", "string", values=stock_tickers, weights=ticker_weights, 
+                baseColumn="trade_id")
+    .withColumn("QUANTITY", "integer", minValue=1, maxValue=100, step=1, random=True)
+    .withColumn("PRICE", "integer", minValue=100, maxValue=110, step=1, random=True)
+    .withColumn("TIMESTAMP", "timestamp", begin="2019-01-02 09:30:00", 
+                end="2019-01-02 16:00:00", 
+                interval="1 second", random=True )
+)
+
+dfTestData2 = testDataSpec.build()
+
+# COMMAND ----------
+
+# DBTITLE 1,Create our demo schema
+# MAGIC %sql 
+# MAGIC CREATE SCHEMA IF NOT EXISTS stock_demo_data;
+
+# COMMAND ----------
+
+# DBTITLE 1,Preview the data
+display(dfTestData2.orderBy("TIMESTAMP"))
+
+# COMMAND ----------
+
+# DBTITLE 1,Write to disk
+dfTestData2.orderBy("TIMESTAMP").write.mode('overwrite').saveAsTable("stock_demo_data.stock_trades")
+
+# COMMAND ----------
+
+# DBTITLE 1,Generate day-by-day stock data
+from pyspark.sql.types import LongType, IntegerType, StringType
+import dbldatagen as dg
+
+shuffle_partitions_requested = 1
+data_rows = 365
+partitions_requested = 1
+
+spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions_requested)
+
+symbols = ["ABC", "DEF", "GHI", "JKLM", "NOP"]
+array_of_dfs = [] 
+for symbol in symbols: 
+  stock_tickers = [
+      symbol
+  ]
+
+  testDataSpec = (
+      dg.DataGenerator(spark, name="stock_data", rows=data_rows, 
+                      partitions=partitions_requested)
+      .withIdOutput()
+      .withColumn("SYMBOL", "string", values=stock_tickers)
+      .withColumn("VOLUME", "integer", minValue=100000, maxValue=1000000, step=10000, random=True)
+      .withColumn("CLOSE", "integer", minValue=100, maxValue=110, step=1, random=True)
+      .withColumn(
+          "LOW",
+          "integer",
+          expr="CLOSE - floor(rand()*10)",
+          baseColumn="CLOSE",
+      )
+      .withColumn(
+          "HIGH",
+          "integer",
+          expr="CLOSE + floor(rand() * 10)",
+          baseColumn="CLOSE",
+      )
+      .withColumn("TIMESTAMP", "timestamp", begin="2019-01-01 16:00:00", 
+                end="2019-12-31 16:00:00", 
+                interval="1 day", random=False)
+  )
+  array_of_dfs.append(testDataSpec.build())
+
+from functools import reduce
+from pyspark.sql import DataFrame
+
+master_df = reduce(DataFrame.unionAll, array_of_dfs)
+
+# COMMAND ----------
+
+# DBTITLE 1,Preview daily stock data
+display(master_df)
+
+# COMMAND ----------
+
+# DBTITLE 1,Write to disk
+master_df.write.mode('overwrite').saveAsTable("stock_demo_data.stock_daily_stats")
+
+# COMMAND ----------
+
+import tecton
+
+#Replace variables your own Tecton API Service Account Key and Tecton URL
+token = dbutils.secrets.get(scope="nicklee", key="TECTON_API_KEY") 
+tecton_url = dbutils.secrets.get(scope="nicklee", key="API_SERVICE")
+
+tecton.set_credentials(token)
+tecton.conf.set("TECTON_CLUSTER_NAME", "tecton-production")
+tecton.test_credentials()
+
+ws = tecton.get_workspace("stock_demo_workspace") 
+
+# COMMAND ----------
+
+# DBTITLE 1,Validate our batch data sources
+from tecton import HiveConfig, BatchSource, DatetimePartitionColumn
+
+stock_daily_stats = BatchSource(
+    name='stock_daily_stats',
+    batch_config=HiveConfig(
+        database='stock_demo_data',
+        table='stock_daily_stats',
+        timestamp_field='TIMESTAMP'
+    ),
+    owner='nlee@tecton.ai',
+    tags={'release': 'production'}
+)
+
+stock_daily_stats.validate()
+
+stock_trades = BatchSource(
+    name='stock_trades_batch',
+    batch_config=HiveConfig(
+        database='stock_demo_data',
+        table='stock_trades',
+        timestamp_field='TIMESTAMP'
+    ),
+    owner='nlee@tecton.ai',
+    tags={'release': 'production'}
+)
+
+stock_trades.validate()
+
+# COMMAND ----------
+
+

--- a/Spark/Financial_Market/sample_notebooks/02_Stock_Features_Demo.py
+++ b/Spark/Financial_Market/sample_notebooks/02_Stock_Features_Demo.py
@@ -16,14 +16,15 @@ tecton.set_credentials(token)
 tecton.conf.set("TECTON_CLUSTER_NAME", "tecton-production")
 tecton.test_credentials()
 
-#Replace with your target workspace in Tecton
-ws = tecton.get_workspace("stock_demo_workspace") 
+#Get your target workspace in Tecton
+#Most of this notebook will work with a development workspace, but you must deploy to a live workspace to enable online serving. 
+ws = tecton.get_workspace("stock_demo_workspace_live") 
 
 # COMMAND ----------
 
 # DBTITLE 1,Inspect stock trades data source
 stock_ds = ws.get_data_source("stock_trades_batch")
-stock_trades_df = stock_ds.get_dataframe(start_time=datetime(2019, 1, 1), end_time=datetime(2019, 12, 31)).to_spark()
+stock_trades_df = stock_ds.get_dataframe(start_time=datetime(2019, 1, 1), end_time=datetime.now()).to_spark()
 
 #Preview data to make sure we can load it from our data source
 display(stock_trades_df)
@@ -32,21 +33,21 @@ display(stock_trades_df)
 
 # DBTITLE 1,Inspect daily stock statistics data source
 stock_daily_ds = ws.get_data_source("stock_daily_stats")
-stock_daily_stats = stock_daily_ds.get_dataframe(start_time=datetime(2019, 1, 1), end_time=datetime(2019, 12, 31)).to_spark()
+stock_daily_stats = stock_daily_ds.get_dataframe(start_time=datetime(2019, 1, 1), end_time=datetime.now()).to_spark()
 display(stock_daily_stats)
 
 # COMMAND ----------
 
 # DBTITLE 1,View our closing price metrics feature view
 stock_max_closing_prices = ws.get_feature_view("closing_prices_metrics")
-stock_max_closing_prices_fv = stock_max_closing_prices.run(datetime(2019, 1, 1), datetime(2022, 1, 1)).to_spark()
+stock_max_closing_prices_fv = stock_max_closing_prices.run(datetime(2019, 1, 1), datetime.now()).to_spark()
 display(stock_max_closing_prices_fv)
 
 # COMMAND ----------
 
 # DBTITLE 1,Inspect stock trades feature view
 stock_daily_transactions = ws.get_feature_view("daily_transactions_stats")
-stock_daily_transactions = stock_daily_transactions.run(datetime(2019, 1, 1), datetime(2022, 1, 1)).to_spark()
+stock_daily_transactions = stock_daily_transactions.run(datetime(2019, 1, 1), datetime.now()).to_spark()
 display(stock_daily_transactions)
 
 # COMMAND ----------
@@ -54,7 +55,7 @@ display(stock_daily_transactions)
 # DBTITLE 1,Build spine for Feature View
 from pyspark.sql import functions as F
 testds = ws.get_feature_view("todays_closing_price")
-test = testds.run(datetime(2019, 1, 2), datetime(2022, 1, 1)).to_spark()
+test = testds.run(datetime.now() - timedelta(days=180), datetime.now()).to_spark() #grab the last 180 days for simplicity
 
 #Add an hour to the spine timestamp so we get that day's closing price when we query that date (we're using a 1 hr batch interval)
 test = test.withColumn('TIMESTAMP_ADJUSTED', F.col("TIMESTAMP") + F.expr('INTERVAL 1 HOURS')) 
@@ -64,12 +65,13 @@ display(test.orderBy("SYMBOL", "TIMESTAMP_ADJUSTED"))
 
 # DBTITLE 1,Test on-demand feature view to compare today's close vs yesterday's close
 odfv_daily_returns = ws.get_feature_view("percentage_daily_returns")
-daily_returns_result = odfv_daily_returns.get_historical_features(spine = test["SYMBOL", "TIMESTAMP_ADJUSTED"], timestamp_key = "TIMESTAMP_ADJUSTED").to_spark()
+daily_returns_result = odfv_daily_returns.get_historical_features(spine = test["SYMBOL", "TIMESTAMP_ADJUSTED"], timestamp_key = "TIMESTAMP_ADJUSTED", from_source=True).to_spark()
 display(daily_returns_result)
 
 # COMMAND ----------
 
 # DBTITLE 1,Feature Service data w/ on-demand features and batch features
+ws = tecton.get_workspace("stock_demo_workspace_live") 
 stock_daily_stats_feature_service = ws.get_feature_service("stock_daily_stats_feature_service")
 
 training_data = stock_daily_stats_feature_service.get_historical_features(
@@ -77,3 +79,35 @@ training_data = stock_daily_stats_feature_service.get_historical_features(
 ).to_spark() 
 
 display(training_data.orderBy("TIMESTAMP_ADJUSTED", "SYMBOL"))
+
+# COMMAND ----------
+
+# DBTITLE 1,After deploying to a live workspace, you can test the real-time feature service
+import requests, json
+
+data = {
+  "params": {
+    "feature_service_name": "stock_daily_stats_feature_service",
+    "join_key_map": {
+      "SYMBOL": "DEF"
+    },
+    "workspace_name": "stock_demo_workspace_live", 
+    "metadataOptions": {"includeNames": True}, 
+  }
+}
+
+# This will only work for a live workspace
+r = requests.post('https://app.tecton.ai/api/v1/feature-service/get-features', data=json.dumps(data), headers={'Authorization': 'Tecton-key ' + token})
+
+response_body = r.json()
+for (a, b) in zip(response_body['result']['features'], response_body['metadata']['features']): 
+  print(b['name'] + ": " + str(a))
+
+
+# COMMAND ----------
+
+
+
+# COMMAND ----------
+
+

--- a/Spark/Financial_Market/sample_notebooks/02_Stock_Features_Demo.py
+++ b/Spark/Financial_Market/sample_notebooks/02_Stock_Features_Demo.py
@@ -1,0 +1,79 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC
+# MAGIC Before running this notebook, make sure you've created your synthetic data and run "tecton apply" with the demo project to define the data sources, feature views, and feature service. 
+
+# COMMAND ----------
+
+import tecton
+from datetime import datetime, timedelta
+
+#Replace variables your own Tecton API Service Account Key and Tecton URL
+token = dbutils.secrets.get(scope="nicklee", key="TECTON_API_KEY") 
+tecton_url = dbutils.secrets.get(scope="nicklee", key="API_SERVICE")
+
+tecton.set_credentials(token)
+tecton.conf.set("TECTON_CLUSTER_NAME", "tecton-production")
+tecton.test_credentials()
+
+#Replace with your target workspace in Tecton
+ws = tecton.get_workspace("stock_demo_workspace") 
+
+# COMMAND ----------
+
+# DBTITLE 1,Inspect stock trades data source
+stock_ds = ws.get_data_source("stock_trades_batch")
+stock_trades_df = stock_ds.get_dataframe(start_time=datetime(2019, 1, 1), end_time=datetime(2019, 12, 31)).to_spark()
+
+#Preview data to make sure we can load it from our data source
+display(stock_trades_df)
+
+# COMMAND ----------
+
+# DBTITLE 1,Inspect daily stock statistics data source
+stock_daily_ds = ws.get_data_source("stock_daily_stats")
+stock_daily_stats = stock_daily_ds.get_dataframe(start_time=datetime(2019, 1, 1), end_time=datetime(2019, 12, 31)).to_spark()
+display(stock_daily_stats)
+
+# COMMAND ----------
+
+# DBTITLE 1,View our closing price metrics feature view
+stock_max_closing_prices = ws.get_feature_view("closing_prices_metrics")
+stock_max_closing_prices_fv = stock_max_closing_prices.run(datetime(2019, 1, 1), datetime(2022, 1, 1)).to_spark()
+display(stock_max_closing_prices_fv)
+
+# COMMAND ----------
+
+# DBTITLE 1,Inspect stock trades feature view
+stock_daily_transactions = ws.get_feature_view("daily_transactions_stats")
+stock_daily_transactions = stock_daily_transactions.run(datetime(2019, 1, 1), datetime(2022, 1, 1)).to_spark()
+display(stock_daily_transactions)
+
+# COMMAND ----------
+
+# DBTITLE 1,Build spine for Feature View
+from pyspark.sql import functions as F
+testds = ws.get_feature_view("todays_closing_price")
+test = testds.run(datetime(2019, 1, 2), datetime(2022, 1, 1)).to_spark()
+
+#Add an hour to the spine timestamp so we get that day's closing price when we query that date (we're using a 1 hr batch interval)
+test = test.withColumn('TIMESTAMP_ADJUSTED', F.col("TIMESTAMP") + F.expr('INTERVAL 1 HOURS')) 
+display(test.orderBy("SYMBOL", "TIMESTAMP_ADJUSTED"))
+
+# COMMAND ----------
+
+# DBTITLE 1,Test on-demand feature view to compare today's close vs yesterday's close
+odfv_daily_returns = ws.get_feature_view("percentage_daily_returns")
+daily_returns_result = odfv_daily_returns.get_historical_features(spine = test["SYMBOL", "TIMESTAMP_ADJUSTED"], timestamp_key = "TIMESTAMP_ADJUSTED").to_spark()
+display(daily_returns_result)
+
+# COMMAND ----------
+
+# DBTITLE 1,Feature Service data w/ on-demand features and batch features
+stock_daily_stats_feature_service = ws.get_feature_service("stock_daily_stats_feature_service")
+
+training_data = stock_daily_stats_feature_service.get_historical_features(
+    spine=test["SYMBOL", "TIMESTAMP_ADJUSTED"], timestamp_key="TIMESTAMP_ADJUSTED", from_source=True
+).to_spark() 
+
+display(training_data.orderBy("TIMESTAMP_ADJUSTED", "SYMBOL"))


### PR DESCRIPTION
I created sample notebooks and code snippets to support a Financial Market Forecasting use-case. Contents: 

i) Financial_Market/sample_notebooks: A notebook you can use to create all the synthetic batch data sources needed for the demo, as well as a second notebook to query Tecton for features. 
ii) Financial_Market/....: Contains data source definitions, entities, batch feature views, ODFV, and Feature Service for example financial market use-case. 

Sample code for a streaming feature view is still in progress. 